### PR TITLE
refactored the graphql code and the logic after the recieved result

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -219,31 +219,175 @@ export const getAllRegions = (publicKey, privateKey) => {
             accessKeyId: "${publicKey}",
             secretAccessKey: "${privateKey}"
           }) {
-            us_east_2_ec2: ec2(config:{
-              region: "us-east-2"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
+            ec2{
+              us_east_2_ec2: describeInstances(config:{
+                region: "us-east-2"
+              }) {
+                ...DescribeInstanceData
+              }
+              us_east_1_ec2:  describeInstances(config:{
+                region: "us-east-1"
+              }) {
+                ...DescribeInstanceData
+              } 
+              us_west_1_ec2:  describeInstances(config:{
+                region: "us-west-1"
+              }) {
+                ...DescribeInstanceData
+              }
+              us_west_2_ec2:  describeInstances(config:{
+                region: "us-west-2"
+              }) {
+                ...DescribeInstanceData
+              }
+              ap_south_1_ec2:  describeInstances(config:{
+                region: "ap-south-1"
+              }) {
+                ...DescribeInstanceData
+              }
+              ap_northeast_2_ec2:  describeInstances(config:{
+                region: "ap-northeast-2"
+              }) {
+                ...DescribeInstanceData
+              }
+              ap_southeast_1_ec2:  describeInstances(config:{
+                region: "ap-southeast-1"
+              }) {
+                ...DescribeInstanceData
+              }
+              ap_southeast_2_ec2:  describeInstances(config:{
+                region: "ap-southeast-2"
+              }) {
+                ...DescribeInstanceData
+              }
+              ap_northeast_1_ec2:  describeInstances(config:{
+                region: "ap-northeast-1"
+              }) {
+                ...DescribeInstanceData
+              }
+              ca_central_1_ec2:  describeInstances(config:{
+                region: "ca-central-1"
+              }) {
+                ...DescribeInstanceData
+              }
+              eu_central_1_ec2:  describeInstances(config:{
+                region: "eu-central-1"
+              }) {
+                ...DescribeInstanceData
+              }
+              eu_west_1_ec2:  describeInstances(config:{
+                region: "eu-west-1"
+              }) {
+                ...DescribeInstanceData
+              }
+              eu_west_2_ec2:  describeInstances(config:{
+                region: "eu-west-2"
+              }) {
+                ...DescribeInstanceData
+              }
+              eu_west_3_ec2: describeInstances(config:{
+                region: "eu-west-3"
+              }) {
+                ...DescribeInstanceData
+              }
+              eu_north_1_ec2:  describeInstances(config:{
+                region: "eu-north-1"
+              }) {
+                ...DescribeInstanceData
+              }
+              sa_east_1_ec2:  describeInstances(config:{
+                region: "sa-east-1"
+              }) {
+                ...DescribeInstanceData
               }
             }
-            us_east_1_ec2: ec2(config:{
-              region: "us-east-1"
-            }) {
-              describeInstances {
+            rds {
+            
+                us_east_2_rds: describeDBInstances(config:{
+                  region: "us-east-2"
+                }) {
+                  ...DbInstanceData
+                }
+                us_east_1_rds: describeDBInstances(config:{
+                  region: "us-east-1"
+                }) {
+                  ...DbInstanceData                  
+                }
+                us_west_1_rds: describeDBInstances(config:{
+                  region: "us-west-1"
+                }) {
+                  ...DbInstanceData
+                }
+                us_west_2_rds: describeDBInstances(config:{
+                  region: "us-west-2"
+                }) {
+                 ...DbInstanceData
+                }
+                ap_south_1_rds: describeDBInstances(config:{
+                  region: "ap-south-1"
+                }) {
+                 ...DbInstanceData
+                }
+                ap_northeast_2_rds: describeDBInstances(config:{
+                  region: "ap-northeast-2"
+                }) {
+                 ...DbInstanceData
+                }
+                ap_southeast_1_rds: describeDBInstances(config:{
+                  region: "ap-southeast-1"
+                }) {
+                  ...DbInstanceData
+                }
+                ap_southeast_2_rds: describeDBInstances(config:{
+                  region: "ap-southeast-2"
+                }) {
+                 ...DbInstanceData
+                }
+                ap_northeast_1_rds: describeDBInstances(config:{
+                  region: "ap-northeast-1"
+                }) {
+                 ...DbInstanceData
+                }
+                ca_central_1_rds: describeDBInstances(config:{
+                  region: "ca-central-1"
+                }) {
+                 ...DbInstanceData
+                }
+                eu_central_1_rds: describeDBInstances(config:{
+                  region: "eu-central-1"
+                }) {
+               ...DbInstanceData
+                }
+                eu_west_1_rds: describeDBInstances(config:{
+                  region: "eu-west-1"
+                }) {
+                  ...DbInstanceData
+                }
+                eu_west_2_rds: describeDBInstances(config:{
+                  region: "eu-west-2"
+                }) {
+                 ...DbInstanceData
+                }
+                eu_west_3_rds: describeDBInstances(config:{
+                  region: "eu-west-3"
+                }) {
+                ...DbInstanceData
+                }
+                eu_north_1_rds: describeDBInstances(config:{
+                  region: "eu-north-1"
+                }) {
+                ...DbInstanceData
+                }
+                sa_east_1_rds: describeDBInstances(config:{
+                  region: "sa-east-1"
+                }) {
+                ...DbInstanceData
+                }
+              } 
+               }
+             }
+            fragment DescribeInstanceData on AwsEC2DescribeInstancesOutput {
+            
                 Reservations {
                   Instances {
                     VpcId
@@ -258,581 +402,25 @@ export const getAllRegions = (publicKey, privateKey) => {
                       GroupId
                     }
                   }
-                }
-              }
-            } 
-            us_west_1_ec2: ec2(config:{
-              region: "us-west-1"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            us_west_2_ec2: ec2(config:{
-              region: "us-west-2"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            ap_south_1_ec2: ec2(config:{
-              region: "ap-south-1"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            ap_northeast_2_ec2: ec2(config:{
-              region: "ap-northeast-2"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            ap_southeast_1_ec2: ec2(config:{
-              region: "ap-southeast-1"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            ap_southeast_2_ec2: ec2(config:{
-              region: "ap-southeast-2"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            ap_northeast_1_ec2: ec2(config:{
-              region: "ap-northeast-1"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            ca_central_1_ec2: ec2(config:{
-              region: "ca-central-1"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            eu_central_1_ec2: ec2(config:{
-              region: "eu-central-1"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            eu_west_1_ec2: ec2(config:{
-              region: "eu-west-1"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            eu_west_2_ec2: ec2(config:{
-              region: "eu-west-2"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            eu_west_3_ec2: ec2(config:{
-              region: "eu-west-3"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            eu_north_1_ec2: ec2(config:{
-              region: "eu-north-1"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
-            sa_east_1_ec2: ec2(config:{
-              region: "sa-east-1"
-            }) {
-              describeInstances {
-                Reservations {
-                  Instances {
-                    VpcId
-                    Placement {
-                      AvailabilityZone
-                    }
-                    State {
-                      Name
-                    }
-                    InstanceId
-                    SecurityGroups {
-                      GroupId
-                    }
-                  }
-                }
-              }
-            }
+                }            
+            }  
             
             
-            
-            
-            us_east_2_rds: rds(config:{
-              region: "us-east-2"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBInstanceStatus
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
+            fragment DbInstanceData on AwsRDSDescribeDBInstancesOutput {
+              DBInstances {
+                DBSubnetGroup{
+                  VpcId
                 }
+                AvailabilityZone
+                DbiResourceId
+                VpcSecurityGroups {
+                  VpcSecurityGroupId
+                }
+                DBInstanceStatus
               }
             }
-            us_east_1_rds: rds(config:{
-              region: "us-east-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBInstanceStatus
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                }
-              }
-            }
-            us_west_1_rds: rds(config:{
-              region: "us-west-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBInstanceStatus
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                }
-              }
-            }
-            us_west_2_rds: rds(config:{
-              region: "us-west-2"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            ap_south_1_rds: rds(config:{
-              region: "ap-south-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            ap_northeast_2_rds: rds(config:{
-              region: "ap-northeast-2"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            ap_southeast_1_rds: rds(config:{
-              region: "ap-southeast-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            ap_southeast_2_rds: rds(config:{
-              region: "ap-southeast-2"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            ap_northeast_1_rds: rds(config:{
-              region: "ap-northeast-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            ca_central_1_rds: rds(config:{
-              region: "ca-central-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            eu_central_1_rds: rds(config:{
-              region: "eu-central-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            eu_west_1_rds: rds(config:{
-              region: "eu-west-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            eu_west_2_rds: rds(config:{
-              region: "eu-west-2"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            eu_west_3_rds: rds(config:{
-              region: "eu-west-3"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            eu_north_1_rds: rds(config:{
-              region: "eu-north-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-            sa_east_1_rds: rds(config:{
-              region: "sa-east-1"
-            }) {
-              describeDBInstances {
-                DBInstances {
-                  DBSubnetGroup {
-                    VpcId
-                  }
-                  AvailabilityZone
-                  DbiResourceId
-                  VpcSecurityGroups {
-                    VpcSecurityGroupId
-                  }
-                  DBInstanceStatus
-                }
-              }
-            }
-          }
-        }
+          
+        
         `
       }
     }).then((result) => {
@@ -840,28 +428,37 @@ export const getAllRegions = (publicKey, privateKey) => {
       const aws = result.data.data.aws;
       let graphData = new compileGraphData();
       let allRegionsPromisesArray = []
-      for (let regions in aws) {
+      // split the objects into two new constants
+      // this is great because we can essentially expand on the many different this that we can model using the cyto library
+      const awsEC2 = aws.ec2;
+      const awsRDS = aws.rds;
+      
+      // recreated this with two for loops, since we have two new objects
+      for (let regions in awsEC2) {
         const regionArray = regions.split("_")
         const regionString = regionArray[0] + "-" + regionArray[1] + "-" + regionArray[2];
-        if (regionArray[3] === "ec2") {
+        // inside this Promise maker, changed the obj(awsEC2), and removed the method it's looking for (.describeInstances)
+        // this is because I restructored the object we received, you don't need to look for the describeInstance, awsECs[regions] is the describeInstance
           allRegionsPromisesArray.push(new Promise( (resolve, reject )=> {
-            graphData.compileEC2Data(aws[regions].describeInstances, regionString)
+            graphData.compileEC2Data(awsEC2[regions], regionString)
             resolve();
-          }));
-          
-        }
-        else if( regionArray[3] === "rds"){
-          allRegionsPromisesArray.push(new Promise( (resolve, reject )=> {
-            graphData.compileRDSData(aws[regions].describeDBInstances, regionString)
-            resolve();
-          }));
+          }));  
+      }  
 
-        }
+      for (let regions in awsRDS) {
+        const regionArray = regions.split("_")
+        const regionString = regionArray[0] + "-" + regionArray[1] + "-" + regionArray[2]; 
+
+        // ********ditto from line 441 
+        allRegionsPromisesArray.push(new Promise( (resolve, reject )=> {
+          graphData.compileRDSData(awsRDS[regions], regionString)
+          resolve();
+        }));
       }
+      
       Promise.all(allRegionsPromisesArray).then( () => {
-        console.log(allRegionsPromisesArray);
-        // graphData.createEdges();
 
+        // graphData.createEdges();
         // const edgeTable = graphData.getEdgesData();
         const edgeTable = [];
       console.log('Heres the graph data for regions: ', edgeTable);


### PR DESCRIPTION
# file:  src/actions/actions.js

## Fragmenting the GraphQL Query

I refactored the old GraphQL code:
I don't think it's completely optimized but I reduced the codebase by 400 lines. 

I split the (result) into two objects (result.data.data.aws.rcs, result.data.data.aws.ec2);

I created a Graphql fragment at the bottom of the query, it is still in-between the back-ticks `
It is essentially the same code as before but without repeating all the keys that we're looking for. Fragments take care of that for us by creating a variable(fragment) that contains the repeated code. 
We spread it out with a spread operator(...). This spread might be different from Javascript's spread. 


## Change Of Logic 

Because response result is split, I had to rewrite the logic. 
Original logic had if cases checking to see if it's either ec2 or rds. 
I removed the if cases, and readjusted the promises to fit the new objects. 

### Tests I ran
I made sure that everything worked the same way, including trailing the logic into (compiledGraphData.js)
None of this code was changed. 
I console.log just about every variable after the query. 

Everything should be working as it was originally.