### PR TITLE
Login/Logout 

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 //this file is the main process (everything that deals with node) of electron
-const { app, BrowserWindow, ipcMain, dialog} = require('electron');
+const { app, BrowserWindow, ipcMain} = require('electron');
 const path = require('path');
 const fs = require('fs');
 
@@ -19,17 +19,18 @@ ipcMain.on('getCredentials', (event, arg) => {
 //login
 ipcMain.on('logIn', (event, arg) => {
   //create folder in root
+  console.log(arg);
   const homedir = require('os').homedir();
-  if (!fs.existsSync(homedir + '/.aws')) fs.mkdir(homedir + '/.aws');
+  if (!fs.existsSync(homedir + '/.aws')) fs.mkdirSync(homedir + '/.aws');
   let content = `[default] 
   aws_access_key_id = ${arg[0]} 
   aws_secret_access_key = ${arg[1]}`;
-  fs.writeFile(homedir + '/.aws/credentials',content);
+  fs.writeFileSync(homedir + '/.aws/credentials',content);
 })
 
 // logout-Delete credentials file and folder
 ipcMain.on('logOut', (event, arg ) => {
-  const homedir = require('os').homedir() + '/.aws/credentials';
+  const homedir = require('os').homedir() + '/.aws';
   rimraf.sync(homedir);
 })
 

--- a/main.js
+++ b/main.js
@@ -19,19 +19,24 @@ ipcMain.on('getCredentials', (event, arg) => {
 //login
 ipcMain.on('logIn', (event, arg) => {
   //create folder in root
-  console.log(arg);
+  //finds root directory
   const homedir = require('os').homedir();
+  //creates .aws folder
   if (!fs.existsSync(homedir + '/.aws')) fs.mkdirSync(homedir + '/.aws');
+  //prepare content with keys
   let content = `[default] 
   aws_access_key_id = ${arg[0]} 
   aws_secret_access_key = ${arg[1]}`;
+  // create and write on credentials file
   fs.writeFileSync(homedir + '/.aws/credentials',content);
+  event.returnValue = 'done';
 })
 
 // logout-Delete credentials file and folder
 ipcMain.on('logOut', (event, arg ) => {
   const homedir = require('os').homedir() + '/.aws';
   rimraf.sync(homedir);
+  event.returnValue = 'done';
 })
 
 // main process for activate electron app

--- a/main.js
+++ b/main.js
@@ -1,10 +1,12 @@
 //this file is the main process (everything that deals with node) of electron
-const { app, BrowserWindow, ipcMain} = require('electron');
+const { app, BrowserWindow, ipcMain, dialog} = require('electron');
 const path = require('path');
-
 const fs = require('fs');
 
-// Login part
+ //Install with npm install rimraf, or just drop rimraf.js somewhere.
+const rimraf = require("rimraf");
+
+// Get credentials
 ipcMain.on('getCredentials', (event, arg) => {
   //finds the folder with the credentials currently hardcoded.
   const homedir = require('os').homedir() +'/.aws/credentials';
@@ -12,6 +14,23 @@ ipcMain.on('getCredentials', (event, arg) => {
   file = file.match(/\=(.*)/g);
   file = [file[0].slice(2),file[1].slice(2)];
   event.returnValue = file;
+})
+
+//login
+ipcMain.on('logIn', (event, arg) => {
+  //create folder in root
+  const homedir = require('os').homedir();
+  if (!fs.existsSync(homedir + '/.aws')) fs.mkdir(homedir + '/.aws');
+  let content = `[default] 
+  aws_access_key_id = ${arg[0]} 
+  aws_secret_access_key = ${arg[1]}`;
+  fs.writeFile(homedir + '/.aws/credentials',content);
+})
+
+// logout-Delete credentials file and folder
+ipcMain.on('logOut', (event, arg ) => {
+  const homedir = require('os').homedir() + '/.aws/credentials';
+  rimraf.sync(homedir);
 })
 
 // main process for activate electron app
@@ -47,3 +66,4 @@ app.on('activate', () => {
     initializeWindow();
   }
 });
+

--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ ipcMain.on('logIn', (event, arg) => {
   if (!fs.existsSync(homedir + '/.aws')) fs.mkdirSync(homedir + '/.aws');
   //prepare content with keys
   let content = `[default] 
-  aws_access_key_id = ${arg[0]} 
+  aws_access_key_id = ${arg[0]}
   aws_secret_access_key = ${arg[1]}`;
   // create and write on credentials file
   fs.writeFileSync(homedir + '/.aws/credentials',content);

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -8,14 +8,13 @@
     
     const params = {};
 
-    export const logIn = (keys) => ({
+    export const logIn = (resp) => ({
       type: actionTypes.LOG_IN,
-      payload: keys
+      payload: resp
     })
 
     export const logOut = (resp) => ({
       type: actionTypes.LOG_OUT,
-      payload: resp
     })
     
     export const getAWSKeys = (keys) => ({

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -7,6 +7,16 @@
     const AWS = require('aws-sdk');
     
     const params = {};
+
+    export const logIn = (keys) => ({
+      type: actionTypes.LOG_IN,
+      payload: keys
+    })
+
+    export const logOut = (resp) => ({
+      type: actionTypes.LOG_OUT,
+      payload: resp
+    })
     
     export const getAWSKeys = (keys) => ({
       type: actionTypes.GET_AWS_KEYS,

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -228,6 +228,8 @@
 
 
 export const getAllRegions = (publicKey, privateKey) => {
+  console.log('public', publicKey);
+  console.log('private', privateKey);
   return(dispatch) => {
     dispatch(getAWSInstancesStart());
     axios({
@@ -435,6 +437,7 @@ export const getAllRegions = (publicKey, privateKey) => {
                 AvailabilityZone
                 DbiResourceId
                 VpcSecurityGroups {
+                  Status
                   VpcSecurityGroupId
                 }
                 DBInstanceStatus
@@ -453,7 +456,7 @@ export const getAllRegions = (publicKey, privateKey) => {
       // this is great because we can essentially expand on the many different this that we can model using the cyto library
       const awsEC2 = aws.ec2;
       const awsRDS = aws.rds;
-      
+      console.log(awsEC2, awsRDS);
       // recreated this with two for loops, since we have two new objects
       for (let regions in awsEC2) {
         const regionArray = regions.split("_")

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -8,9 +8,8 @@
     
     const params = {};
 
-    export const logIn = (resp) => ({
+    export const logIn = () => ({
       type: actionTypes.LOG_IN,
-      payload: resp
     })
 
     export const logOut = (resp) => ({

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -12,7 +12,7 @@
       type: actionTypes.LOG_IN,
     })
 
-    export const logOut = (resp) => ({
+    export const logOut = () => ({
       type: actionTypes.LOG_OUT,
     })
     

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,0 +1,40 @@
+import React, {Component} from 'react';
+const {ipcRenderer} = require('electron');
+
+class Login extends Component{
+    constructor(props){
+        super(props)
+        this.state ={
+         publicKey: '',
+         secretKey: ''   
+       }
+       this.handleChange = this.handleChange.bind(this);
+       this.handleSubmit = this.handleSubmit.bind(this);
+      }
+
+    handleChange(field, fieldName){
+        return this.setState(state => ({
+            [fieldName] : field
+        }))
+    }
+    handleSubmit(publicKey, secretKey){
+        ipcRenderer.sendSync('logIn', publicKey, secretKey);
+        this.props.logIn();
+        return this.setState(state => ({
+            publicKey:'',
+            secretKey: ''
+        }))
+    }
+    render() {
+      return (
+          <div id="loginContainer">
+              <p id='Welcome'>Mira, Mira</p>
+              <input type='text' id='publicKey' onChange={(e)=>{this.handleChange(e.target.value, 'publicKey')}}></input>
+              <input type='text' id='secretKey' onChange={(e)=>{this.handleChange(e.target.value, 'secretKey')}}></input>
+              <button onClick={(e)=>{this.handleSubmit(this.props.publicKey, this.props.secretKey)}}>login</button>
+          </div>
+      )
+    }
+  }
+  
+  export default Login;

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -22,7 +22,6 @@ class Login extends Component{
     }
     handleSubmit(publicKey, secretKey){
         ipcRenderer.sendSync('logIn', [publicKey, secretKey]);
-        console.log('is it here?');
         this.props.logIn();
         return this.setState(state => ({
             publicKey:'',

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,6 +1,9 @@
 import React, {Component} from 'react';
 const {ipcRenderer} = require('electron');
 
+// import { connect } from 'react-redux';
+
+
 class Login extends Component{
     constructor(props){
         super(props)
@@ -18,7 +21,8 @@ class Login extends Component{
         }))
     }
     handleSubmit(publicKey, secretKey){
-        ipcRenderer.sendSync('logIn', publicKey, secretKey);
+        ipcRenderer.sendSync('logIn', [publicKey, secretKey]);
+        console.log('is it here?');
         this.props.logIn();
         return this.setState(state => ({
             publicKey:'',
@@ -26,12 +30,14 @@ class Login extends Component{
         }))
     }
     render() {
+      console.log(this.state);
+      console.log(this.props.loginKey);
       return (
           <div id="loginContainer">
               <p id='Welcome'>Mira, Mira</p>
-              <input type='text' id='publicKey' onChange={(e)=>{this.handleChange(e.target.value, 'publicKey')}}></input>
-              <input type='text' id='secretKey' onChange={(e)=>{this.handleChange(e.target.value, 'secretKey')}}></input>
-              <button onClick={(e)=>{this.handleSubmit(this.props.publicKey, this.props.secretKey)}}>login</button>
+              <input type='text' id='publicKey' placeholder='public access key' onChange={(e)=>{this.handleChange(e.target.value, 'publicKey')}}></input>
+              <input type='text' id='secretKey' placeholder='secret access key'onChange={(e)=>{this.handleChange(e.target.value, 'secretKey')}}></input>
+              <button onClick={(e)=>{this.handleSubmit(this.state.publicKey, this.state.secretKey)}}>login</button>
           </div>
       )
     }

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -3,6 +3,10 @@ import axios from 'axios';
 import { getAWSInstances } from '../actions/actions';
 import Select from 'react-select';
 
+const mapDispatchToProps = dispatch => ({
+  logOut: () => { dispatch(actions.logOut())
+  }
+}) 
 
 class Menu extends Component {
   constructor(props){
@@ -56,6 +60,15 @@ class Menu extends Component {
         else this.props.getAWSInstances(this.props.currentRegion);
       }
     };
+     // Log out--  notifies main.js about change and changes action 
+    const handleLogOut = () => {
+       //emits event to the back-end
+       let reply = ipcRenderer.sendSync('logOut'); // render process sends info to electron via ipcRendered
+       this.props.getAWSKeys(reply); // getAWSkeys is takes payload from action which is login and password
+        // add login reducer just for login operations
+        this.props.logOut()
+    }
+
     return (
       <div id="Menu">
         {/* select component for html in react jsx */}
@@ -66,10 +79,11 @@ class Menu extends Component {
           options={options}
           />
        <button id="refresh" onClick={refresh}>Refresh</button>
-       <button id="logout">Log Out</button>
+       <button id="logOut" onClick={handleLogOut}>Log Out</button>
       </div>
     );
   }
 }
 
-export default Menu;
+
+export default connect(mapStateToProps, mapDispatchToProps)(Menu);

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
-import axios from 'axios';
-import { getAWSInstances } from '../actions/actions';
 import Select from 'react-select';
 import { connect } from 'react-redux';
 const {ipcRenderer} = require('electron');
 import * as actions from "../actions/actions.js";
 
 const mapDispatchToProps = dispatch => ({
-  logOut: () => { dispatch(actions.logOut())
+  logOut: () => {
+     dispatch(actions.logOut())
   }
 }) 
 
@@ -67,7 +66,7 @@ class Menu extends Component {
     const handleLogOut = () => {
        //emits event to the back-end
        ipcRenderer.sendSync('logOut'); // render process sends info to electron via ipcRendered
-        this.props.logOut()
+       this.props.logOut()
     }
 
     return (
@@ -87,4 +86,4 @@ class Menu extends Component {
 }
 
 
-export default connect(mapDispatchToProps)(Menu);
+export default connect(null,mapDispatchToProps)(Menu);

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -4,7 +4,7 @@ import { getAWSInstances } from '../actions/actions';
 import Select from 'react-select';
 import { connect } from 'react-redux';
 const {ipcRenderer} = require('electron');
-
+import * as actions from "../actions/actions.js";
 
 const mapDispatchToProps = dispatch => ({
   logOut: () => { dispatch(actions.logOut())
@@ -66,9 +66,7 @@ class Menu extends Component {
      // Log out--  notifies main.js about change and changes action 
     const handleLogOut = () => {
        //emits event to the back-end
-       let reply = ipcRenderer.sendSync('logOut'); // render process sends info to electron via ipcRendered
-       this.props.getAWSKeys(reply); // getAWSkeys is takes payload from action which is login and password
-        // add login reducer just for login operations
+       ipcRenderer.sendSync('logOut'); // render process sends info to electron via ipcRendered
         this.props.logOut()
     }
 

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -65,7 +65,7 @@ class Menu extends Component {
           options={options}
           />
        <button id="refresh" onClick={refresh}>Refresh</button>
-       <button id="logout" >Log Out</button>
+       <button id="logout">Log Out</button>
       </div>
     );
   }

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { getAWSInstances } from '../actions/actions';
 import Select from 'react-select';
 
+
 class Menu extends Component {
   constructor(props){
     super(props)

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -65,6 +65,7 @@ class Menu extends Component {
           options={options}
           />
        <button id="refresh" onClick={refresh}>Refresh</button>
+       <button id="logout" >Log Out</button>
       </div>
     );
   }

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -2,6 +2,9 @@ import React, { Component } from 'react';
 import axios from 'axios';
 import { getAWSInstances } from '../actions/actions';
 import Select from 'react-select';
+import { connect } from 'react-redux';
+const {ipcRenderer} = require('electron');
+
 
 const mapDispatchToProps = dispatch => ({
   logOut: () => { dispatch(actions.logOut())
@@ -86,4 +89,4 @@ class Menu extends Component {
 }
 
 
-export default connect(mapStateToProps, mapDispatchToProps)(Menu);
+export default connect(mapDispatchToProps)(Menu);

--- a/src/constants/actionTypes.js
+++ b/src/constants/actionTypes.js
@@ -6,4 +6,6 @@ export const GET_AWS_INSTANCES_START = 'GET_AWS_INSTANCES_START';
 export const GET_AWS_INSTANCES_FINISHED ='GET_AWS_INSTANCES_FINISHED';
 export const GET_AWS_INSTANCES_ERROR = 'GET_AWS_INSTANCES_ERROR';
 export const GET_ALL_REGIONS = 'GET_ALL_REGIONS';
-export const GET_AWS_KEYS = 'GET_AWS_KEYS';
+export const GET_AWS_KEYS = 'GET_AWS_KEYS'; //when main container mounts after login
+export const LOG_IN = 'LOG_IN'; // should change login state to true and create AWS folder
+export const LOG_OUT = 'LOG_OUT'; // should delete IAM on AWS, delete folder .aws and change login state to false

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -1,6 +1,5 @@
 //wrapper container for the entire react
 import React, {Component} from "react";
-import ReactDOM from "react-dom";
 // import store from "../store";
 import MainContainer from "./mainContainer";
 import Menu from "../components/Menu.jsx"

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -49,6 +49,7 @@ const mapDispatchToProps = dispatch => ({
 class App extends Component{
 
   render(){
+    console.log(this.props);
     let display = [];
     display.push(<Menu publicKey={this.props.publicKey} privateKey={this.props.privateKey} getAWSInstances={this.props.getAWSInstances} currentRegion={this.props.currentRegion} getAllRegions={this.props.getAllRegions} />);
     display.push(<MainContainer getAWSKeys={this.props.getAWSKeys} getAWSInstances={this.props.getAWSInstances} regionData={this.props.regionData} 

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -6,7 +6,6 @@ import MainContainer from "./mainContainer";
 import Menu from "../components/Menu.jsx"
 import * as actions from "../actions/actions.js";
 import { connect } from 'react-redux';
-const {ipcRenderer} = require('electron');
 
 // mainprocess.test() // was testing for credentials
 const mapStateToProps = store => ({
@@ -42,19 +41,11 @@ const mapDispatchToProps = dispatch => ({
 
 class App extends Component{
 
-  componentDidMount() {
-    //emits event to the back-end
-    let reply = ipcRenderer.sendSync('getCredentials'); // render process sends info to electron via ipcRendered
-    this.props.getAWSKeys(reply); // getAWSkeys is takes payload from action which is login and password
-  // add login reducer just for login operations
-}
-
-
   render(){
     return(
       <div id="app">
         <Menu publicKey={this.props.publicKey} privateKey={this.props.privateKey} getAWSInstances={this.props.getAWSInstances} currentRegion={this.props.currentRegion} getAllRegions={this.props.getAllRegions} />
-        <MainContainer getAWSInstances={this.props.getAWSInstances} regionData={this.props.regionData} 
+        <MainContainer getAWSKeys={this.props.getAWSKeys} getAWSInstances={this.props.getAWSInstances} regionData={this.props.regionData} 
         getNodeDetails={this.props.getNodeDetails} activeNode={this.props.activeNode} fetchingFlag={this.props.fetchingFlag} finishedFlag={this.props.finishedFlag}
         edgeTable= {this.props.edgeTable}/>
 {/* 

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -18,8 +18,8 @@ const mapStateToProps = store => ({
   // sgRelationships: store.graph.sgRelationships,
   fetchingFlag: store.graph.fetching,
   finishedFlag: store.graph.fetched,
-  publicKey: store.graph.awsPublicKey,
-  privateKey: store.graph.awsPrivateKey
+  publicKey: store.login.awsPublicKey,
+  privateKey: store.login.awsPrivateKey
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -18,7 +18,8 @@ const mapStateToProps = store => ({
   fetchingFlag: store.graph.fetching,
   finishedFlag: store.graph.fetched,
   publicKey: store.login.awsPublicKey,
-  privateKey: store.login.awsPrivateKey
+  privateKey: store.login.awsPrivateKey,
+  loginKey: store.login.loginKey
 })
 
 const mapDispatchToProps = dispatch => ({
@@ -30,27 +31,31 @@ const mapDispatchToProps = dispatch => ({
     getNodeDetails: (data) => {
       dispatch(actions.getNodeDetails(data));
     },
+
     getAllRegions: (publicKey, privateKey) => {
       dispatch(actions.getAllRegions(publicKey,privateKey));
     },
     //get credentials from folder on computer
     getAWSKeys: (keys) => {
       dispatch(actions.getAWSKeys(keys));
+    },
+    //login state 
+    logIn: () => {
+      dispatch(actions.logIn());
     }
 })
 
 class App extends Component{
 
   render(){
+    let display = [];
+    display.push(<Menu publicKey={this.props.publicKey} privateKey={this.props.privateKey} getAWSInstances={this.props.getAWSInstances} currentRegion={this.props.currentRegion} getAllRegions={this.props.getAllRegions} />);
+    display.push(<MainContainer getAWSKeys={this.props.getAWSKeys} getAWSInstances={this.props.getAWSInstances} regionData={this.props.regionData} 
+      getNodeDetails={this.props.getNodeDetails} activeNode={this.props.activeNode} fetchingFlag={this.props.fetchingFlag} finishedFlag={this.props.finishedFlag}
+      edgeTable= {this.props.edgeTable}/>);
     return(
       <div id="app">
-        <Menu publicKey={this.props.publicKey} privateKey={this.props.privateKey} getAWSInstances={this.props.getAWSInstances} currentRegion={this.props.currentRegion} getAllRegions={this.props.getAllRegions} />
-        <MainContainer getAWSKeys={this.props.getAWSKeys} getAWSInstances={this.props.getAWSInstances} regionData={this.props.regionData} 
-        getNodeDetails={this.props.getNodeDetails} activeNode={this.props.activeNode} fetchingFlag={this.props.fetchingFlag} finishedFlag={this.props.finishedFlag}
-        edgeTable= {this.props.edgeTable}/>
-{/* 
-        sgRelationships={this.props.sgRelationships}
-        sgNodeCorrelations={this.props.sgNodeCorrelations}/> */}
+        {loginKey ? <Login logIn={this.props.logIn}/> : {display}}
       </div>
     )
   }

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom";
 // import store from "../store";
 import MainContainer from "./mainContainer";
 import Menu from "../components/Menu.jsx"
+import Login from "../components/Login.jsx"
 import * as actions from "../actions/actions.js";
 import { connect } from 'react-redux';
 
@@ -55,7 +56,7 @@ class App extends Component{
       edgeTable= {this.props.edgeTable}/>);
     return(
       <div id="app">
-        {loginKey ? <Login logIn={this.props.logIn}/> : {display}}
+        {this.props.loginKey ? display : <Login loginKey={this.props.loginKey} logIn={this.props.logIn}/> }
       </div>
     )
   }

--- a/src/containers/mainContainer.jsx
+++ b/src/containers/mainContainer.jsx
@@ -3,7 +3,6 @@ import Graph from "../components/Graph";
 import Side_Panel from "../components/Side_Panel";
 const {ipcRenderer} = require('electron');
 
-
 class MainContainer extends Component{
   //SIDE PANEL RENDERS CONDITIONALLY
   componentDidMount() {

--- a/src/containers/mainContainer.jsx
+++ b/src/containers/mainContainer.jsx
@@ -1,10 +1,17 @@
 import React, {Component} from 'react';
 import Graph from "../components/Graph";
 import Side_Panel from "../components/Side_Panel";
+const {ipcRenderer} = require('electron');
 
 
 class MainContainer extends Component{
   //SIDE PANEL RENDERS CONDITIONALLY
+  componentDidMount() {
+    //emits event to the back-end
+    let reply = ipcRenderer.sendSync('getCredentials'); // render process sends info to electron via ipcRendered
+    this.props.getAWSKeys(reply); // getAWSkeys is takes payload from action which is login and password
+  // add login reducer just for login operations
+}
   render() {
     return (
         <div id="mainContainer">

--- a/src/reducers/graphReducer.js
+++ b/src/reducers/graphReducer.js
@@ -9,9 +9,7 @@ const initialState = {
     activeNode: '',
     fetching: false,
     fetched: false,
-    allRegions: {},
-    awsPublicKey: '',
-    awsPrivateKey: '',
+    allRegions: {}
 }
 
 // should possibly rename this reducer
@@ -29,16 +27,6 @@ const graphReducer = (state = initialState, action) => {
           ...state,
           fetching:false,
           fetched: true
-        }
-      }
-      //separate login into a new reducer file.
-      //sets state with the credentials found on folder
-      //encrypt on folder decrypt on set redux state
-      case actionTypes.GET_AWS_KEYS: {
-        return {
-          ...state,
-          awsPublicKey: action.payload[0],
-          awsPrivateKey: action.payload[1]
         }
       }
       case actionTypes.GET_AWS_INSTANCES: {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,6 +6,7 @@ import graphReducer from './graphReducer';
 // combine reducers
 const reducers = combineReducers({
   graph: graphReducer,
+  login: loginReducer
   // fill in more later if we have more reducers
 });
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,7 @@
 import { combineReducers } from 'redux';
 import graphReducer from './graphReducer';
+import loginReducer from './loginReducer';
+
 
 // import all reducers here
 

--- a/src/reducers/loginReducer.js
+++ b/src/reducers/loginReducer.js
@@ -1,0 +1,38 @@
+import * as actionTypes from '../constants/actionTypes';
+
+const initialState = {
+    login: false,
+    awsPublicKey: '',
+    awsPrivateKey: '',
+}
+
+const loginReducer = (state = initialState, action) => {
+    switch(action.type){
+      //separate login into a new reducer file.
+      //sets state with the credentials found on folder
+      //encrypt on folder decrypt on set redux state
+      case actionTypes.GET_AWS_KEYS: {
+        return {
+            ...state,
+            awsPublicKey: action.payload[0],
+            awsPrivateKey: action.payload[1]
+        }
+      }
+        case actionTypes.LOG_IN: {
+            return {
+                ...state,
+                login: true,
+                awsPublicKey: action.payload[0],
+                awsPrivateKey: action.payload[1]
+            }
+        }
+        case actionTypes.LOG_OUT: {
+            return {
+
+            }
+        }
+        default: return state;
+    }
+}
+
+export default loginReducer;

--- a/src/reducers/loginReducer.js
+++ b/src/reducers/loginReducer.js
@@ -21,7 +21,7 @@ const loginReducer = (state = initialState, action) => {
         case actionTypes.LOG_IN: {
             return {
                 ...state,
-                login: true
+                loginKey: true
             }
         }
         case actionTypes.LOG_OUT: {

--- a/src/reducers/loginReducer.js
+++ b/src/reducers/loginReducer.js
@@ -1,7 +1,7 @@
 import * as actionTypes from '../constants/actionTypes';
 
 const initialState = {
-    login: false,
+    loginKey: false,
     awsPublicKey: '',
     awsPrivateKey: '',
 }
@@ -21,14 +21,13 @@ const loginReducer = (state = initialState, action) => {
         case actionTypes.LOG_IN: {
             return {
                 ...state,
-                login: true,
-                awsPublicKey: action.payload[0],
-                awsPrivateKey: action.payload[1]
+                login: true
             }
         }
         case actionTypes.LOG_OUT: {
             return {
-
+                ...state,
+                loginKey : false,
             }
         }
         default: return state;


### PR DESCRIPTION
### ActionTypes.js
Created `LOG_IN` and `LOG_OUT` actiontypes os state management of the conditional render of the login component.

### GraphReducers.js
Took out `GET_AWS_KEYS` and moved to **LoginReducer.js** to manage all login actions in one separate file.

### LoginReducers.js
Three actions reducers to manage login/logout:
`LOG_IN`: changes state of loginKey to allow conditional render
`GET_AWS_KEYS`: gets keys from the .aws folder and sets it in state for graphql queries in `actions.js`
`LOG_OUT`:  changes state of loginKey to trigger original login component to render

### Index.js
Added `loginReducer.js` to the redux store

### Actions.js
Created three actions:
`logIn`: no payload, only updates state to true
`logOut`: no payload, only updates state to false
`getAWSkeys`: payloads carry the keys found in the .aws folder

### App.jsx
- Moved `componentDidMount` that fetches the keys from .aws folder to `Menu.jsx`, this way the login page renders even if there aren't any saved keys yet.
- `mapStateToProps` the `loginKey` to use it as flag for the conditional render of the `Login.jsx `component and `mapDispatchtoProps` the `logIn` action from the store.
- Created `display` variable on render to use on the conditional statement for the components.
- Created `Login.jsx` component with `logIn` action from store and `loginKey` as props.

### Login.jsx
Stateful component with:
- `handleChange` method to save input from input area in the component `OnChange`.
- `handleSubmit` method to emit (`icpRenderer.sendsync`) to `Main.js` (or the main process of the electron app) the access keys used by user. Then, it runs the `logIn` action to update state and render the `Menu.jsx` and `MainContainer.jsx` components. Finally, it clears the state used to `handleChange` of inputs.

### MainContainer.jsx
Added `ComponentDidMount` to fetch keys from .aws folder for graphQl queries in `actions.js`

### Menu.jsx
- `mapDispatchtoProps `to get `logOut` action in props
- Added `logOut` button 
- Added event handler for `logOut` on click. Emits (`icpRenderer.sendsync`) to `Main.js` to run `logOut` steps on the main process of the electron app.

### Main.js
- Listens (`icpMain.on`) to `logIn` channel. Finds home directory of current computer with `require('os').homedir()`. Creates .aws folder with `mkdir`. Creates and write on `credentials `file with `fs.writeFileSync`. `Event.returnvalue` finalizes the listening event.
- Listens (`icpMain.on`) to `logOut` channel. Finds .aws folder and deletes it. 

### Final Comments
Logout does not delete IAM user from AWS. There is an sdk method that does it. For it to run, we will have to request the IAM username on login.
The sdk does make if safer since it doesn't save the key to state, but although GraphQL requires the keys in state, it makes the queries easier. What is the best approach?
