### PR TITLE
 Please don't break, this is the answer to that darn queryAll bug

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -465,7 +465,7 @@ export const getAllRegions = (publicKey, privateKey) => {
         // this is because I restructored the object we received, you don't need to look for the describeInstance, awsECs[regions] is the describeInstance
           allRegionsPromisesArray.push(new Promise( (resolve, reject )=> {
             graphData.compileEC2Data(awsEC2[regions], regionString)
-            resolve();
+            .then(() => resolve());
           }));  
       }  
 
@@ -476,26 +476,24 @@ export const getAllRegions = (publicKey, privateKey) => {
         // ********ditto from line 441 
         allRegionsPromisesArray.push(new Promise( (resolve, reject )=> {
           graphData.compileRDSData(awsRDS[regions], regionString)
-          resolve();
+            .then(() => resolve());
         }));
       }
       
       Promise.all(allRegionsPromisesArray).then( () => {
-
-        // graphData.createEdges();
-        // const edgeTable = graphData.getEdgesData();
-        const edgeTable = [];
-      console.log('Heres the graph data for regions: ', edgeTable);
-      const regionState = graphData.getRegionData();
-      dispatch(getAWSInstancesFinished());
-      dispatch({
-        type: actionTypes.GET_AWS_INSTANCES,
-        payload: {
-          regionState,
-          edgeTable,
-          currentRegion: 'all',
-        },
-      });
+        graphData.createEdges();
+        const edgeTable = graphData.getEdgesData();
+        console.log('Heres the graph data for regions: ', edgeTable);
+        const regionState = graphData.getRegionData();
+        dispatch(getAWSInstancesFinished());
+        dispatch({
+          type: actionTypes.GET_AWS_INSTANCES,
+          payload: {
+            regionState,
+            edgeTable,
+            currentRegion: 'all',
+          },
+        });
       })
     })
   }

--- a/src/assets/compileGraphData.js
+++ b/src/assets/compileGraphData.js
@@ -33,93 +33,31 @@ class compileGraphData {
   }
 
   compileRDSData(data,region){
-    AWS.config.update({
-      region,
-    });
-    this.ec2  = new AWS.EC2({});
+    return new Promise((originalResolve, originalReject) => {
+      AWS.config.update({
+        region,
+      });
+      this.ec2  = new AWS.EC2({});
       const innerPromiseArray =[];
-
-        for(let i = 0; i < data.DBInstances.length; i ++){
-            let DBinstances = data.DBInstances[i];
-            //destructure the data for relevant data
-            let {DBSubnetGroup: {VpcId}, AvailabilityZone, DbiResourceId, VpcSecurityGroups} = DBinstances;
-            // if the property doesn't exist within the object, create an object to save all the data in
-            if(!this.regionState.hasOwnProperty(VpcId))this.regionState[VpcId] = {};
-            if(!this.regionState[VpcId].hasOwnProperty(AvailabilityZone))this.regionState[VpcId][AvailabilityZone] = {};
-            if(!this.regionState[VpcId][AvailabilityZone].hasOwnProperty("RDS"))this.regionState[VpcId][AvailabilityZone].RDS ={};
-            //save the data into the this.regionState object
-            this.regionState[VpcId].region = options[region];
-            this.regionState[VpcId][AvailabilityZone].RDS[DbiResourceId] = DBinstances;
-
-            innerPromiseArray.push(new Promise((resolve,reject) => {
-              const param = {
-                GroupIds:[]
-              };
-              for(let k = 0; k < VpcSecurityGroups.length; k++){
-                param.GroupIds.push(VpcSecurityGroups[k].VpcSecurityGroupId); 
-                
-              }
-              this.ec2.describeSecurityGroups(param, (err, data) => {
-                if (err) {
-                  console.log(err, err.stack);
-                  reject();
-                }
-                else{
-
-                  this.regionState[VpcId][AvailabilityZone].RDS[DbiResourceId].MySecurityGroups = data.SecurityGroups;
-                  for(let h = 0; h < data.SecurityGroups.length; h++){
-
-                    if(!this.sgNodeCorrelations[data.SecurityGroups[h].GroupId]) this.sgNodeCorrelations[data.SecurityGroups[h].GroupId]  = new Set();
-                    this.sgNodeCorrelations[data.SecurityGroups[h].GroupId].add(DbiResourceId);
-
-                    if(data.SecurityGroups[h].IpPermissions.length > 0){
-                      for(let i = 0; i < data.SecurityGroups[h].IpPermissions[0].UserIdGroupPairs.length; i++ ){
-                        this.sgRelationships.push([data.SecurityGroups[h].IpPermissions[0].UserIdGroupPairs[i].GroupId, data.SecurityGroups[h].GroupId])
-
-                      }
-                    }
-                  }
-                  resolve();
-
-                }
-              } )
-            }))
-
-            
-
-
-          }
-
-          Promise.all(innerPromiseArray).then(() => {
-
-            // console.log("sgnodre correlations", this.sgNodeCorrelations);
-    // console.log("sgRelationshisps ", this.sgRelationships)
-          });
-  }
-
-  compileEC2Data(data, region){
-    AWS.config.update({
-      region,
-    });
-    this.ec2 = new AWS.EC2({});
-    const innerPromiseArray =[];
-    for(let i = 0; i < data.Reservations.length; i ++){
-      let instances = data.Reservations[i].Instances;
-      for( let j = 0; j < instances.length; j++){
-        let {VpcId, Placement: {AvailabilityZone}, InstanceId, SecurityGroups} = instances[j];
+  
+      for(let i = 0; i < data.DBInstances.length; i++) {
+        let DBinstances = data.DBInstances[i];
+        //destructure the data for relevant data
+        let {DBSubnetGroup: {VpcId}, AvailabilityZone, DbiResourceId, VpcSecurityGroups} = DBinstances;
+        // if the property doesn't exist within the object, create an object to save all the data in
         if(!this.regionState.hasOwnProperty(VpcId))this.regionState[VpcId] = {};
         if(!this.regionState[VpcId].hasOwnProperty(AvailabilityZone))this.regionState[VpcId][AvailabilityZone] = {};
-        if(!this.regionState[VpcId][AvailabilityZone].hasOwnProperty("EC2"))this.regionState[VpcId][AvailabilityZone].EC2 = {};
+        if(!this.regionState[VpcId][AvailabilityZone].hasOwnProperty("RDS"))this.regionState[VpcId][AvailabilityZone].RDS ={};
+        //save the data into the this.regionState object
         this.regionState[VpcId].region = options[region];
-        this.regionState[VpcId][AvailabilityZone].EC2[InstanceId] = instances[j];
-        
-        //making a new promise to query for information about security group related to each EC2
+        this.regionState[VpcId][AvailabilityZone].RDS[DbiResourceId] = DBinstances;
+  
         innerPromiseArray.push(new Promise((resolve,reject) => {
           const param = {
             GroupIds:[]
           };
-          for(let k = 0; k < SecurityGroups.length; k++){
-            param.GroupIds.push(SecurityGroups[k].GroupId); 
+          for(let k = 0; k < VpcSecurityGroups.length; k++){
+            param.GroupIds.push(VpcSecurityGroups[k].VpcSecurityGroupId);
           }
           this.ec2.describeSecurityGroups(param, (err, data) => {
             if (err) {
@@ -127,45 +65,109 @@ class compileGraphData {
               reject();
             }
             else {
-                  this.regionState[VpcId][AvailabilityZone].EC2[InstanceId].MySecurityGroups = data.SecurityGroups;
-                  for(let h = 0; h < data.SecurityGroups.length; h++){
-                   
-                    if(!this.sgNodeCorrelations[data.SecurityGroups[h].GroupId]) this.sgNodeCorrelations[data.SecurityGroups[h].GroupId]  = new Set();
-                    this.sgNodeCorrelations[data.SecurityGroups[h].GroupId].add(InstanceId);
-                    
-                    if(data.SecurityGroups[h].IpPermissions.length > 0){
-                    
-                      for(let i = 0; i < data.SecurityGroups[h].IpPermissions[0].UserIdGroupPairs.length; i++ ){
-                        this.sgRelationships.push([data.SecurityGroups[h].IpPermissions[0].UserIdGroupPairs[i].GroupId, data.SecurityGroups[h].GroupId])
-
-                      }
-                    }
+              console.log('promise 1', this.sgRelationships, this.sgRelationships.length);
+              this.regionState[VpcId][AvailabilityZone].RDS[DbiResourceId].MySecurityGroups = data.SecurityGroups;
+              for(let h = 0; h < data.SecurityGroups.length; h++){
+                if(!this.sgNodeCorrelations[data.SecurityGroups[h].GroupId]) this.sgNodeCorrelations[data.SecurityGroups[h].GroupId]  = new Set();
+                this.sgNodeCorrelations[data.SecurityGroups[h].GroupId].add(DbiResourceId);
+  
+                if(data.SecurityGroups[h].IpPermissions.length > 0){
+                  for(let i = 0; i < data.SecurityGroups[h].IpPermissions[0].UserIdGroupPairs.length; i++ ){
+                    this.sgRelationships.push([data.SecurityGroups[h].IpPermissions[0].UserIdGroupPairs[i].GroupId, data.SecurityGroups[h].GroupId])
+                    console.log('promise 2', this.sgRelationships, this.sgRelationships.length)
                   }
-                  // console.log("Node relations ", this.sgNodeCorrelations)
-                  resolve();
+                }
+              }
+              resolve();
             }
-          })
+          });
         }));
-        
       }
-    }
-
-    Promise.all(innerPromiseArray).then(() => {
-      // console.log("inner promise array ", innerPromiseArray);
-      // console.log("sgnodre correlations", this.sgNodeCorrelations);
-    // console.log("sgRelationshisps ", this.sgRelationships)
+  
+      console.log(innerPromiseArray);
+  
+      Promise.all(innerPromiseArray)
+        .then((data) => {
+          console.log('promise 3', data, this.sgRelationships, this.sgRelationships.length)
+          originalResolve();
+        })
+        .catch(err => originalReject(err));
     });
   }
-  createEdges(){
-    console.log("sgnodre correlations", this.sgNodeCorrelations);
-    console.log("sgRelationshisps ", this.sgRelationships)
-     for(let i = 0; i < this.sgRelationships.length; i++){
-      this.sgNodeCorrelations[this.sgRelationships[i][0]].forEach( function(val1, val2, set){
-        this.sgNodeCorrelations[this.sgRelationships[i][1]].forEach( function(value1, value2, set2){
-        if(!this.edgeTable.hasOwnProperty(val1)) this.edgeTable[val1]= new Set();
-          this.edgeTable[val1].add(value1);
+
+  compileEC2Data(data, region){
+    return new Promise((originalResolve, originalReject) => {
+      AWS.config.update({
+        region,
+      });
+      this.ec2 = new AWS.EC2({});
+      const innerPromiseArray =[];
+      for(let i = 0; i < data.Reservations.length; i ++){
+        let instances = data.Reservations[i].Instances;
+        for( let j = 0; j < instances.length; j++){
+          let {VpcId, Placement: {AvailabilityZone}, InstanceId, SecurityGroups} = instances[j];
+          if(!this.regionState.hasOwnProperty(VpcId))this.regionState[VpcId] = {};
+          if(!this.regionState[VpcId].hasOwnProperty(AvailabilityZone))this.regionState[VpcId][AvailabilityZone] = {};
+          if(!this.regionState[VpcId][AvailabilityZone].hasOwnProperty("EC2"))this.regionState[VpcId][AvailabilityZone].EC2 = {};
+          this.regionState[VpcId].region = options[region];
+          this.regionState[VpcId][AvailabilityZone].EC2[InstanceId] = instances[j];
+          
+          //making a new promise to query for information about security group related to each EC2
+          innerPromiseArray.push(new Promise((resolve,reject) => {
+            const param = {
+              GroupIds:[]
+            };
+            for(let k = 0; k < SecurityGroups.length; k++){
+              param.GroupIds.push(SecurityGroups[k].GroupId); 
+            }
+            this.ec2.describeSecurityGroups(param, (err, data) => {
+              if (err) {
+                console.log(err, err.stack);
+                reject();
+              }
+              else {
+                    this.regionState[VpcId][AvailabilityZone].EC2[InstanceId].MySecurityGroups = data.SecurityGroups;
+                    for(let h = 0; h < data.SecurityGroups.length; h++){
+                    
+                      if(!this.sgNodeCorrelations[data.SecurityGroups[h].GroupId]) this.sgNodeCorrelations[data.SecurityGroups[h].GroupId]  = new Set();
+                      this.sgNodeCorrelations[data.SecurityGroups[h].GroupId].add(InstanceId);
+                      
+                      if(data.SecurityGroups[h].IpPermissions.length > 0){
+                      
+                        for(let i = 0; i < data.SecurityGroups[h].IpPermissions[0].UserIdGroupPairs.length; i++ ){
+                          this.sgRelationships.push([data.SecurityGroups[h].IpPermissions[0].UserIdGroupPairs[i].GroupId, data.SecurityGroups[h].GroupId])
+
+                        }
+                      }
+                    }
+                    // console.log("Node relations ", this.sgNodeCorrelations)
+                    resolve();
+              }
+            })
+          }));
+          
+        }
+      }
+
+      Promise.all(innerPromiseArray)
+        .then(() => {
+          originalResolve();
         })
-      })
+        .catch(err => originalReject(err));
+    })
+  }
+
+  createEdges(){
+     for(let i = 0; i < this.sgRelationships.length; i++){
+     const firstParam = Array.from( this.sgNodeCorrelations[this.sgRelationships[i][0]]);
+     const id = firstParam[0];
+     const secondParam = Array.from(this.sgNodeCorrelations[this.sgRelationships[i][1]]);
+     const sg = secondParam[0];
+      if(!this.edgeTable.hasOwnProperty(id)){ 
+        this.edgeTable[id]= new Set();
+    
+      }      
+      this.edgeTable[id].add(sg);
     }
 
     console.log("the edge tables",this.edgeTable) 


### PR DESCRIPTION

## actions/actions.js
Our promises that we were pushing for getAllRegions query WERE being resolved at its push because we weren’t returning a promise when we invoked grapData.compileEC2Data || graphData.compileRDSData.
	To Solve this, I made both those methods return a promise(so many, I know. I’ll stop, I promise). 
	Now our allRegionsPromiseArray actually does what it was originally intended to do.  

I un-commented a method call after the promiseAll logic resolves. Now we use graphData.getEdgesData(); 
and  save its return value as edgeTable, which we dispatch to the store. 
This will create all the arrows we desire. 



## Assets/compileGraphData.js
Wrapped all the logic inside both compileRDSData && compileEC2Data(separately) into two huge Promises that we return at the function invocations. 
	This makes it so that in actions/actions.js, we have to wait for both to actually resolve. 

Lastly, I refactored the createEdges method logic. Instead of a forEach call on these sets, I made it so that we use Array.from instead and grabbed its first(and only) element.
	This might need some refactoring, but the logic works for now. 
