### PR TITLE
Fixing delete in AllRegions & Security group buttons conditional render

### DIFF
--- a/src/components/InstanceCreator.jsx
+++ b/src/components/InstanceCreator.jsx
@@ -78,6 +78,11 @@ class InstanceCreator extends Component {
 event.preventDefault();
 }
   deleteInstance() {
+    let nodeRegion = this.props.activeNode.Placement.AvailabilityZone;
+    let regionArr = nodeRegion.split('');
+    regionArr.pop();
+    let regionStr = regionArr.join('');
+    console.log(regionStr);
     console.log(this.source.value);
     console.log(this.props.activeNode);
     let instanceId = this.source.value;
@@ -98,7 +103,7 @@ event.preventDefault();
       })
     }
     function deleteSG(){ return new Promise((resolve, reject)=>{
-      let ec2 = new AWS.EC2();
+      let ec2 = new AWS.EC2({region:regionStr});
       let paramsSG = {
        GroupId: `${activeNode.SecurityGroups[0].GroupId}`
       }
@@ -116,7 +121,7 @@ event.preventDefault();
     let params = {
       InstanceIds: [`${instanceId}`],
     }
-    let ec2 = new AWS.EC2();
+    let ec2 = new AWS.EC2({region:regionStr});
 
     function deleteEC2(){return new Promise((resolve,reject)=>{
       ec2.terminateInstances(params, function (err, data) {
@@ -148,7 +153,7 @@ event.preventDefault();
         DBInstanceIdentifier: `${instanceId}`,
         SkipFinalSnapshot: true
       };
-      let rds = new AWS.RDS();
+      let rds = new AWS.RDS({region:regionStr});
       function deleteRDS(){ return new Promise((resolve, reject)=>{
         rds.deleteDBInstance(params, function(err, data) {
           if (err){

--- a/src/components/InstanceCreator.jsx
+++ b/src/components/InstanceCreator.jsx
@@ -82,6 +82,7 @@ event.preventDefault();
     console.log(this.props.activeNode);
     let instanceId = this.source.value;
     let activeNode = this.props.activeNode;
+    let requests = 0;
     // console.log('instanceid', `${instanceId}`);
     // console.log(this.type.value);
     function checkSG(){return new Promise((resolve, reject)=>{
@@ -103,7 +104,10 @@ event.preventDefault();
        GroupId: `${activeNode.SecurityGroups[0].GroupId}`
       };
       ec2.deleteSecurityGroup(paramsSG, function(err, data) {
-        if (err) reject(err); // an error occurred
+        if (err){
+          if(requests > 5) reject(err);
+          setTimeout(deleteSG(),60000); 
+        } // an error occurred
         else resolve(data);          // successful response
       });
      })

--- a/src/components/InstanceCreator.jsx
+++ b/src/components/InstanceCreator.jsx
@@ -82,7 +82,6 @@ event.preventDefault();
     console.log(this.props.activeNode);
     let instanceId = this.source.value;
     let activeNode = this.props.activeNode;
-    let requests = 0;
     // console.log('instanceid', `${instanceId}`);
     // console.log(this.type.value);
     function checkSG(){return new Promise((resolve, reject)=>{
@@ -102,13 +101,10 @@ event.preventDefault();
       let ec2 = new AWS.EC2();
       let paramsSG = {
        GroupId: `${activeNode.SecurityGroups[0].GroupId}`
-      };
-      requests++;
-      console.log('#',requests);
+      }
       ec2.deleteSecurityGroup(paramsSG, function(err, data) {
         if (err){
-          if(requests > 110) reject(err);
-          else setTimeout(deleteSG(),60000); 
+          reject(err); 
         } // an error occurred
         else resolve(data);          // successful response
       });

--- a/src/components/InstanceCreator.jsx
+++ b/src/components/InstanceCreator.jsx
@@ -103,10 +103,12 @@ event.preventDefault();
       let paramsSG = {
        GroupId: `${activeNode.SecurityGroups[0].GroupId}`
       };
+      requests++;
+      console.log('#',requests);
       ec2.deleteSecurityGroup(paramsSG, function(err, data) {
         if (err){
-          if(requests > 5) reject(err);
-          setTimeout(deleteSG(),60000); 
+          if(requests > 110) reject(err);
+          else setTimeout(deleteSG(),60000); 
         } // an error occurred
         else resolve(data);          // successful response
       });

--- a/src/components/InstanceCreator.jsx
+++ b/src/components/InstanceCreator.jsx
@@ -67,11 +67,11 @@ class InstanceCreator extends Component {
 	
 	change(event) {
 		this.setState({ value: event.target.value });
-		if (this.props.selectedRegion.value === "all" || this.state.inputRegion !== null) AWS.config.update({region: inAllRegions[this.state.inputRegion]})
-		else AWS.config.update({ region: this.props.selectedRegion.value }); //updates arguments region, maxRetries, logger
 		console.log("HERE IS CURRENT REGION=>", AWS.config.region)		
 	}
 	handleSubmit() {
+		if (this.props.selectedRegion.value === "all" || this.state.inputRegion !== null) AWS.config.update({region: inAllRegions[this.state.inputRegion]})
+		else AWS.config.update({ region: this.props.selectedRegion.value }); //updates arguments region, maxRetries, logger
 		const ec2 = new AWS.EC2();
 		const rds = new AWS.RDS();
 		let sg = this.state.sg;
@@ -140,7 +140,10 @@ class InstanceCreator extends Component {
 				console.log("SECURITY GROUP HAS BEEN CREATED")
 				createEC2Instance()
 			})
-			.then(data => console.log(data))
+			.then(data => {
+				console.log(data); 
+				this.props.onRequestClose();
+			})
 			.catch(err => console.log(err))
 			
 			event.preventDefault();
@@ -256,21 +259,26 @@ class InstanceCreator extends Component {
   }
 
   render(){
+	  let imgOptions = [];
+	  for(let key in inAllRegions){
+		  console.log('key', key);
+		  imgOptions.push(<option value={key}>{inAllRegions[key]}</option>)
+	  }
+	  console.log('options:', imgOptions);
     // console.log('active node: ', this.props.activeNode);
   		let displayCreate = [<form>
         <div>Create New Instances</div>
         <select id="instance" onChange={this.change} value={this.state.value}>
           <option value="select">Select Instance</option>
           <option value="EC2">EC2</option>
-          <option value="RDS">RDS</option>
         </select>
-        {/* <select id="instanceType">
-          <option value="">Instance Type 1</option>
-          <option value="">Instance Type 2</option>
-          <option value="">Instance Type 3</option>
-        </select>
-        <br /> */}
-		<input type="text" defaultValue={imageId[AWS.config.region]} onChange={e => this.changeRegion(e)} />
+		<p>Region Image Id:</p>
+		<select id='select-img' defaultValue={imageId[AWS.config.region]} onChange={e => this.changeRegion(e)}>
+			{imgOptions}
+		</select>
+		<br />
+		<p>Key Pair Name:</p>
+		<input type="text" ref={input => (this.keyPair = input)}/>
 		<br />
         <button onClick={this.handleSubmit}>Create Instance</button>
       </form>];

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -107,7 +107,7 @@ class Menu extends Component {
           <Select id='select-menu' value={this.state.selectedOption} onChange={handleChange} options={options}/>
           <button id="refresh" onClick={refresh}><img id="refreshimg" src="../src/assets/refresh.png"/></button> 
           <Modal isOpen={this.state.modalIsOpen} onRequestClose={this.closeModal} style={customStyles} contentLabel="Instance Modal">
-            <InstanceCreator delete={this.state.delete} activeNode={this.props.activeNode} onRequestClose={this.closeModal}/>
+            <InstanceCreator selectedRegion={this.state.selectedOption} delete={this.state.delete} activeNode={this.props.activeNode} onRequestClose={this.closeModal}/>
             <button onClick={this.closeModal}>close</button>
           </Modal>
           <button id='deleteInstance' onClick={(e)=>{this.openModal('delete')}}>Delete</button>

--- a/src/components/Security_Group_Edit.jsx
+++ b/src/components/Security_Group_Edit.jsx
@@ -39,22 +39,6 @@ class Security_Group_Edit extends Component {
       index: event.target.value
     });
   }
-  // handleInOut(event) {
-  //   this.getSgTotal();
-  //   if(event.target.value === 'inbound' && this.state.inbound === false){
-  //     this.setState({
-  //       inbound: true,
-  //       outbound: false
-  //     })
-  //   }
-  //   if(event.target.value === 'outbound' && this.state.outbound === false){
-  //     this.setState({
-  //       inbound: false,
-  //       outbound: true
-  //     })
-  //   }
-  // }
-
   checkSource(input) {
     const cidrRegex ="^([0-9]{1,3}.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$";
     if (input.match(cidrRegex)) return true;
@@ -71,7 +55,6 @@ class Security_Group_Edit extends Component {
       toPort = ranges.length > 1 ? ranges[1]:ranges[0];
     }
     // async call to do get the api, then refresh
-    console.log("type of ", typeof this.source.value);
     const ec2 = new AWS.EC2();
     const paramsIn = {
       GroupId: this.GroupId.value, //selected node
@@ -79,7 +62,8 @@ class Security_Group_Edit extends Component {
       {
         FromPort: ranges[0],
         IpProtocol: this.protocol.value,
-        ToPort: toPort
+        ToPort: toPort,
+        UserIdGroupPairs: [{ GroupId: this.GroupId.value }]
       }
       ]
     };
@@ -89,7 +73,8 @@ class Security_Group_Edit extends Component {
         {
         FromPort: ranges[0],
         IpProtocol: this.protocol.value,
-        ToPort: toPort
+        ToPort: toPort,
+        UserIdGroupPairs: [{ GroupId: this.source.value }]
         }
       ]
     };
@@ -141,7 +126,7 @@ class Security_Group_Edit extends Component {
     function editSGPromisesOut(){
       return new Promise((resolve, reject)=>{
         ec2.authorizeSecurityGroupEgress(paramsOut, function(err, data) {
-          if (err) {
+          if(err) {
             console.log("Data not inputted in correct format", err, err.stack); // an error occurred
             reject(err);
           }
@@ -198,7 +183,7 @@ class Security_Group_Edit extends Component {
           .then(() => {
             editSGPromisesOut();
           })
-          .then(() => {
+          .then(() =>{ 
             this.props.onRequestClose();
             // console.log('Got the result: ' + result);
           })
@@ -254,6 +239,7 @@ class Security_Group_Edit extends Component {
   }
 
   render() {
+    
     const AutofillData = [
       {
         type: "Custom TCP Rule",

--- a/src/components/Side_Panel.jsx
+++ b/src/components/Side_Panel.jsx
@@ -4,7 +4,7 @@ import SecGroupEdit from './Security_Group_Edit';
 import Modal from 'react-modal';
 import Collapsible from 'react-collapsible';
 // import {Switch, BrowserRouter as Router, Route, NavLink, withRouter } from 'react-router-dom';
-import Delete from "react-collapsible";
+
 
 const customStyles = {
   content: {

--- a/src/components/Side_Panel.jsx
+++ b/src/components/Side_Panel.jsx
@@ -95,29 +95,33 @@ class Side_Panel extends Component {
         "Security Group Details": this.props.activeNode.MySecurityGroups
       };
       // console.log("fdsjfdhsjk", securityGroupNames);
-      sgmodal = (
-        <button id="modal-pop-up" onClick={this.openModal}>
-          Edit Security Groups
+      if(this.props.currentRegion !== 'all') {
+        sgmodal =(
+          <div>
+          <button id="modal-pop-up" onClick={this.openModal}>
+            Add SG Rules
+          </button>
+          <button
+          id="deleteBtn"
+          onClick={() => {
+            // console.log(
+            //   "this is current delete statement =>",
+            //   this.state.delete
+            // );
+            this.delete();
+            this.openModal();
+          }}
+        >
+          Delete SG rules
         </button>
-      );
+        </div>
+        );
+     }
       console.log(this.props.activeNode);
       NodeDetails = (
         <div id="details-wrapper">
           <Collapsible trigger="Node Summary" open="true">
             {sgmodal}
-            <button
-              id="deleteBtn"
-              onClick={() => {
-                // console.log(
-                //   "this is current delete statement =>",
-                //   this.state.delete
-                // );
-                this.delete();
-                this.openModal();
-              }}
-            >
-              Delete SG rules
-            </button>
             <p>
               <span className="sidebar-title">Instance Type: </span>
               <span>{this.props.activeNode.InstanceId ? "EC2" : "RDS"}</span>

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -53,7 +53,7 @@ class App extends Component{
     display.push(<Menu activeNode={this.props.activeNode} publicKey={this.props.publicKey} privateKey={this.props.privateKey} getAWSInstances={this.props.getAWSInstances} currentRegion={this.props.currentRegion} getAllRegions={this.props.getAllRegions} />);
     display.push(<MainContainer getAWSKeys={this.props.getAWSKeys} getAWSInstances={this.props.getAWSInstances} regionData={this.props.regionData} 
       getNodeDetails={this.props.getNodeDetails} activeNode={this.props.activeNode} fetchingFlag={this.props.fetchingFlag} finishedFlag={this.props.finishedFlag}
-      edgeTable= {this.props.edgeTable}/>);
+      edgeTable= {this.props.edgeTable} currentRegion={this.props.currentRegion}/>);
     return(
       <div id="app">
         {this.props.loginKey ? display : <Login loginKey={this.props.loginKey} logIn={this.props.logIn}/> }

--- a/src/containers/mainContainer.jsx
+++ b/src/containers/mainContainer.jsx
@@ -18,7 +18,7 @@ class MainContainer extends Component{
           edgeTable= {this.props.edgeTable}/>
           {/* sgRelationships={this.props.sgRelationships}
           sgNodeCorrelations={this.props.sgNodeCorrelations}/> */}
-          <Side_Panel regionData={this.props.regionData} activeNode={this.props.activeNode}/>
+          <Side_Panel currentRegion={this.props.currentRegion} regionData={this.props.regionData} activeNode={this.props.activeNode}/>
         </div>
     )
   }


### PR DESCRIPTION
### InstanceCreator.jsx
- Included the logic to work on all regions by sending down the region of the selected node:
```
  let nodeRegion = this.props.activeNode.Placement.AvailabilityZone;
    let regionArr = nodeRegion.split('');
    regionArr.pop();
    let regionStr = regionArr.join('');
```

this breaks down the region from the availability zone só I can add it on the new instance of the AWS service:
`let ec2 = new AWS.EC2({region:regionStr});`

- Had to paste my code over because of merge conflicts from last pull from hotfixes

### SecurityGroupEdit.jsx
- Deleted commented function that was not in use
- Added group Id's in params for more precise sdk command

### SidePanel.jsx
- Added delete button logic inside variable `sgmodal` to place together with add sg rules.
- Added if statement with `this.props.currentRegion` for conditional render

### App.jsx
- Passed down currentRegion as props to `MainContainer`

### MainContainer.jsx
- Passed down currentRegion as props to `Side_Panel`



